### PR TITLE
Add scene QC syntax gate and prompt safeguards

### DIFF
--- a/docs/SCENE_QC_AGENT_PROMPT.md
+++ b/docs/SCENE_QC_AGENT_PROMPT.md
@@ -25,6 +25,7 @@ Hard requirements:
    - No `self.wait(...)` with duration `<= 0`.
    - No animation `run_time < 0.3`.
    - Avoid expressions that can collapse to zero waits (example: `a - a`).
+   - Do not leave literal `"\\n"` escape text inside Python code; use actual newlines.
 2. Fix narration sync issues.
    - Within each `with self.voiceover(...) as tracker:` block, keep total timing budget at or below narration duration.
    - Remove over-allocation patterns that cause dead air.
@@ -64,6 +65,7 @@ Required report format:
   - exact fix applied
   - why it resolves sync/layout risk
 - Include any residual risks that need deterministic script validation.
+- The report must be present and non-empty.
 
 ## Operational Notes
 

--- a/prompts/scene_qc_prompt.md
+++ b/prompts/scene_qc_prompt.md
@@ -8,8 +8,9 @@ Primary instructions:
 - Validate and patch scene files listed below (from project_state.json):
 {{SCENE_FILES}}
 - Keep creative intent; fix timing sync and overlap/layout defects.
+- Write real newlines in Python code (never literal "\\n" escapes in source).
 - Do NOT edit project_state.json.
-- Write a report file named scene_qc_report.md in this directory.
+- Write a non-empty report file named scene_qc_report.md in this directory.
 
 Attached files include:
 - project_state.json


### PR DESCRIPTION
## Summary
- add backup + post-QC py_compile gate with rollback to scene QC phase in build_video.sh
- harden scene QC prompts to forbid literal \n escapes and require non-empty reports
- document requirements in SCENE_QC_AGENT_PROMPT.md

## Testing
- ./scripts/build_video.sh /workspaces/flaming-horse/projects/qc-regression-demo
