### PR TITLE
[codex] Strengthen first-pass scene creation

### DIFF
--- a/harness_responses/client.py
+++ b/harness_responses/client.py
@@ -166,7 +166,13 @@ def _compact_schema_contract(schema: Type[BaseModel]) -> str:
             ]
         ),
         "NarrationResponse": "Return one JSON object with script: an object mapping narration keys to narration text strings.",
-        "BuildScenesResponse": "Return one JSON object with scene_body: a string containing only scaffold-slot Python statements.",
+        "BuildScenesResponse": (
+            "Return one JSON object with scene_body: a string containing only "
+            "first-pass-valid scaffold-slot Python statements. The scene_body must "
+            "not include imports, classes, defs, config edits, voiceover wrappers, "
+            "comments, markdown, XML, or scaffold markers, and it must use "
+            "tracker.duration for timing."
+        ),
         "SceneQcResponse": "Return one JSON object with report_markdown: a string.",
         "SceneRepairResponse": "Return one JSON object with scene_body: a string containing the repaired scaffold-slot Python statements.",
     }

--- a/harness_responses/parser.py
+++ b/harness_responses/parser.py
@@ -10,8 +10,10 @@ No dependencies on harness/.
 """
 
 import ast
+import io
 import json
 import re
+import tokenize
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -298,10 +300,12 @@ def _validate_scene_body_contract(
     def fail(msg: str) -> None:
         _fail_with_diag(project_dir, raw_response, extracted_content, f"{phase}.{msg}")
 
-    for line_no, line in enumerate(scene_body.splitlines(), start=1):
-        stripped = line.strip()
-        if stripped.startswith("#"):
-            fail(f"scene_body line {line_no} must not contain comments")
+    try:
+        for token in tokenize.generate_tokens(io.StringIO(scene_body).readline):
+            if token.type == tokenize.COMMENT:
+                fail(f"scene_body line {token.start[0]} must not contain comments")
+    except tokenize.TokenError as exc:
+        fail(f"scene_body must be valid Python statements: {exc}")
 
     try:
         tree = ast.parse(scene_body)
@@ -329,7 +333,49 @@ def _validate_scene_body_contract(
             return node.attr
         return ""
 
+    def attribute_root_name(node: ast.AST) -> str:
+        current = node
+        while isinstance(current, ast.Attribute):
+            current = current.value
+        if isinstance(current, ast.Name):
+            return current.id
+        return ""
+
+    def target_touches_config(target: ast.AST) -> bool:
+        return (
+            isinstance(target, ast.Name)
+            and target.id == "config"
+        ) or (
+            isinstance(target, ast.Attribute)
+            and attribute_root_name(target) == "config"
+        )
+
+    def is_self_voiceover_call(node: ast.AST) -> bool:
+        return (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "voiceover"
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "self"
+        )
+
     for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and any(target_touches_config(t) for t in node.targets):
+            fail("scene_body must not modify Manim config")
+        if isinstance(node, ast.AnnAssign) and target_touches_config(node.target):
+            fail("scene_body must not modify Manim config")
+        if isinstance(node, ast.AugAssign) and target_touches_config(node.target):
+            fail("scene_body must not modify Manim config")
+        if isinstance(node, ast.With):
+            for item in node.items:
+                if is_self_voiceover_call(item.context_expr):
+                    fail("scaffold owns the voiceover wrapper")
+        if isinstance(node, ast.Name) and node.id == "random":
+            fail("scene_body must be deterministic and not use random")
+        if isinstance(node, ast.Attribute) and (
+            node.attr == "random" or attribute_root_name(node) == "random"
+        ):
+            fail("scene_body must be deterministic and not use random")
         if not isinstance(node, ast.Call):
             continue
         name = call_name(node.func)
@@ -349,33 +395,6 @@ def _validate_scene_body_contract(
                     fail("set_color(list(...)) is not Manim-compatible")
                 if first_name == "harmonious_color":
                     fail("select a concrete Manim-compatible color before set_color(...)")
-
-    forbidden_patterns: list[tuple[str, str]] = [
-        (r"(?m)^\s*config\s*\.", "scene_body must not modify Manim config"),
-        (r"with\s+self\.voiceover\s*\(", "scaffold owns the voiceover wrapper"),
-        (r"#\s*SLOT_(START|END):scene_body", "scene_body must not include slot markers"),
-        (r"```", "scene_body must not include markdown fences"),
-        (r"</?scene_body\b", "scene_body must not include XML scene_body tags"),
-        (r"\bShowCreation\s*\(", "Use Create(...) instead of ShowCreation(...)"),
-        (
-            r"FadeIn\([^\n)]*lag_ratio\s*=",
-            "Use LaggedStart(..., lag_ratio=...) instead of FadeIn(..., lag_ratio=...)",
-        ),
-        (
-            r"FadeIn\([^\n)]*scale_factor\s*=",
-            "FadeIn(..., scale_factor=...) is unsupported",
-        ),
-        (r"&lt;|&gt;", "scene_body must use Python operators, not escaped HTML operators"),
-        (r"set_color\(\s*list\(", "set_color(list(...)) is not Manim-compatible"),
-        (
-            r"set_color\(\s*harmonious_color\(",
-            "select a concrete Manim-compatible color before set_color(...)",
-        ),
-        (r"\b(?:np\.)?random\b", "scene_body must be deterministic and not use random"),
-    ]
-    for pattern, message in forbidden_patterns:
-        if re.search(pattern, scene_body):
-            fail(message)
 
     if "tracker.duration" not in scene_body:
         fail("scene_body must use tracker.duration for narration-synced timing")

--- a/harness_responses/parser.py
+++ b/harness_responses/parser.py
@@ -9,6 +9,7 @@ Responsibilities:
 No dependencies on harness/.
 """
 
+import ast
 import json
 import re
 from datetime import datetime, timezone
@@ -276,7 +277,108 @@ def _normalize_and_validate_scene_body(
             extracted_content,
             f"{phase}.scene_body cannot be empty",
         )
+    _validate_scene_body_contract(
+        phase=phase,
+        scene_body=candidate,
+        project_dir=project_dir,
+        raw_response=raw_response,
+        extracted_content=extracted_content,
+    )
     return candidate
+
+
+def _validate_scene_body_contract(
+    *,
+    phase: str,
+    scene_body: str,
+    project_dir: Path,
+    raw_response: Any,
+    extracted_content: Any,
+) -> None:
+    def fail(msg: str) -> None:
+        _fail_with_diag(project_dir, raw_response, extracted_content, f"{phase}.{msg}")
+
+    for line_no, line in enumerate(scene_body.splitlines(), start=1):
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            fail(f"scene_body line {line_no} must not contain comments")
+
+    try:
+        tree = ast.parse(scene_body)
+    except SyntaxError as exc:
+        fail(f"scene_body must be valid Python statements: {exc}")
+
+    forbidden_nodes = (
+        ast.Import,
+        ast.ImportFrom,
+        ast.ClassDef,
+        ast.FunctionDef,
+        ast.AsyncFunctionDef,
+    )
+    for node in ast.walk(tree):
+        if isinstance(node, forbidden_nodes):
+            fail(
+                "scene_body must not include imports, class definitions, "
+                "or function definitions"
+            )
+
+    def call_name(node: ast.AST) -> str:
+        if isinstance(node, ast.Name):
+            return node.id
+        if isinstance(node, ast.Attribute):
+            return node.attr
+        return ""
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        name = call_name(node.func)
+        if name == "ShowCreation":
+            fail("Use Create(...) instead of ShowCreation(...)")
+        if name == "FadeIn":
+            kw_names = {kw.arg for kw in node.keywords if kw.arg}
+            if "lag_ratio" in kw_names:
+                fail("Use LaggedStart(..., lag_ratio=...) instead of FadeIn(..., lag_ratio=...)")
+            if "scale_factor" in kw_names:
+                fail("FadeIn(..., scale_factor=...) is unsupported")
+        if name == "set_color" and node.args:
+            first_arg = node.args[0]
+            if isinstance(first_arg, ast.Call):
+                first_name = call_name(first_arg.func)
+                if first_name == "list":
+                    fail("set_color(list(...)) is not Manim-compatible")
+                if first_name == "harmonious_color":
+                    fail("select a concrete Manim-compatible color before set_color(...)")
+
+    forbidden_patterns: list[tuple[str, str]] = [
+        (r"(?m)^\s*config\s*\.", "scene_body must not modify Manim config"),
+        (r"with\s+self\.voiceover\s*\(", "scaffold owns the voiceover wrapper"),
+        (r"#\s*SLOT_(START|END):scene_body", "scene_body must not include slot markers"),
+        (r"```", "scene_body must not include markdown fences"),
+        (r"</?scene_body\b", "scene_body must not include XML scene_body tags"),
+        (r"\bShowCreation\s*\(", "Use Create(...) instead of ShowCreation(...)"),
+        (
+            r"FadeIn\([^\n)]*lag_ratio\s*=",
+            "Use LaggedStart(..., lag_ratio=...) instead of FadeIn(..., lag_ratio=...)",
+        ),
+        (
+            r"FadeIn\([^\n)]*scale_factor\s*=",
+            "FadeIn(..., scale_factor=...) is unsupported",
+        ),
+        (r"&lt;|&gt;", "scene_body must use Python operators, not escaped HTML operators"),
+        (r"set_color\(\s*list\(", "set_color(list(...)) is not Manim-compatible"),
+        (
+            r"set_color\(\s*harmonious_color\(",
+            "select a concrete Manim-compatible color before set_color(...)",
+        ),
+        (r"\b(?:np\.)?random\b", "scene_body must be deterministic and not use random"),
+    ]
+    for pattern, message in forbidden_patterns:
+        if re.search(pattern, scene_body):
+            fail(message)
+
+    if "tracker.duration" not in scene_body:
+        fail("scene_body must use tracker.duration for narration-synced timing")
 
 
 def _resolve_scene_file_for_build(project_dir: Path) -> Path:

--- a/harness_responses/parser.py
+++ b/harness_responses/parser.py
@@ -359,7 +359,18 @@ def _validate_scene_body_contract(
             and node.func.value.id == "self"
         )
 
+    def is_tracker_duration(node: ast.AST) -> bool:
+        return (
+            isinstance(node, ast.Attribute)
+            and node.attr == "duration"
+            and isinstance(node.value, ast.Name)
+            and node.value.id == "tracker"
+        )
+
+    uses_tracker_duration = False
     for node in ast.walk(tree):
+        if is_tracker_duration(node):
+            uses_tracker_duration = True
         if isinstance(node, ast.Assign) and any(target_touches_config(t) for t in node.targets):
             fail("scene_body must not modify Manim config")
         if isinstance(node, ast.AnnAssign) and target_touches_config(node.target):
@@ -396,7 +407,7 @@ def _validate_scene_body_contract(
                 if first_name == "harmonious_color":
                     fail("select a concrete Manim-compatible color before set_color(...)")
 
-    if "tracker.duration" not in scene_body:
+    if not uses_tracker_duration:
         fail("scene_body must use tracker.duration for narration-synced timing")
 
 

--- a/harness_responses/prompts/build_scenes/system.md
+++ b/harness_responses/prompts/build_scenes/system.md
@@ -4,8 +4,14 @@ System role:
 You are an expert Manim programmer creating compelling animations.
 
 System objective:
-Produce high-quality scene content that is semantically faithful to narration and plan intent.
+Produce first-pass-valid scene content that is semantically faithful to narration and plan intent.
 Follow run-specific output format and hard requirements from the user prompt.
+
+First-pass validity target:
+- Your `scene_body` is expected to pass the deterministic scene gates before repair:
+  scaffold structure, Python syntax, import/API validation, voiceover sync,
+  timing budget validation, semantic placeholder checks, and Manim dry-run.
+- `scene_repair` is a fallback for defects, not the primary authoring path.
 
 Local framework reference:
 - Read the local prompt, template, scaffold, plan, narration, and current scene
@@ -13,3 +19,9 @@ Local framework reference:
 - Use common Manim CE APIs that are valid inside the generated scene scaffold.
 - Prefer conservative, well-known constructs over speculative classes,
   parameters, color constants, or animation APIs.
+
+Conservative Manim subset:
+- Mobjects: `Text`, `MathTex`, `VGroup`, `Circle`, `Line`, `Arrow`,
+  `NumberPlane`, `Axes`, `Dot`, `Rectangle`.
+- Animations: `Create`, `Write`, `FadeIn`, `FadeOut`, `Transform`,
+  `ReplacementTransform`, `LaggedStart`.

--- a/harness_responses/prompts/build_scenes/user.md
+++ b/harness_responses/prompts/build_scenes/user.md
@@ -19,6 +19,8 @@ Timing guidance:
 - Estimated narration duration: `{{estimated_duration_text}}` (`{{estimated_duration_seconds}}s`)
 - Use `tracker.duration` in timing math (`run_time=` and/or `self.wait(...)`).
 - Keep total projected time <= `tracker.duration * 0.95`.
+- Allocate timing explicitly across the scene and end with a bounded
+  `self.wait(max(0.1, tracker.duration * ...))` or equivalent bounded wait.
 
 {{reference_section}}
 {{retry_section}}
@@ -30,12 +32,33 @@ Output requirements:
 - `self.play(...)`
 - `self.wait(...)`
 - method calls on mobjects
-3. Do not include imports, class/function definitions, comments, or scaffold markers.
+3. Do not include imports, class/function definitions, comments, config edits, or scaffold markers.
 4. Do not include `with self.voiceover(...)`; scaffold already provides it.
 5. Keep title text exactly `{{scene_title}}`.
 6. Keep SCRIPT key exactly `SCRIPT["{{narration_key}}"]`.
 7. Use deterministic code; do not use `random`.
 8. Return JSON only (no markdown/code fences/XML/explanations).
 
+First-pass validation target:
+- The scene body must be designed to pass scaffold structure, Python syntax,
+  import/API validation, voiceover sync, timing budget validation, semantic
+  placeholder checks, and `manim render --dry_run` without repair.
+
+Use this conservative Manim subset unless the scene genuinely requires more:
+- Mobjects: `Text`, `MathTex`, `VGroup`, `Circle`, `Line`, `Arrow`,
+  `NumberPlane`, `Axes`, `Dot`, `Rectangle`.
+- Animations: `Create`, `Write`, `FadeIn`, `FadeOut`, `Transform`,
+  `ReplacementTransform`, `LaggedStart`.
+
+Forbidden known failure sources:
+- `ShowCreation`; use `Create`.
+- `FadeIn(..., lag_ratio=...)`; use `LaggedStart`.
+- `FadeIn(..., scale_factor=...)`.
+- Escaped HTML operators such as `&lt;` and `&gt;`.
+- Invalid color arrays such as `set_color(list(...))` or
+  `set_color(harmonious_color(...))`.
+- `with self.voiceover(...)`, imports, classes, defs, config edits, comments,
+  scaffold markers, randomness, markdown fences, XML, or explanations.
+
 Example JSON shape:
-{"scene_body": "title = Text(\"{{scene_title}}\")\\nself.play(Write(title), run_time=min(1.0, tracker.duration * 0.10))"}
+{"scene_body": "title = Text(\"{{scene_title}}\")\\nself.play(Write(title), run_time=min(1.0, tracker.duration * 0.10))\\nself.wait(max(0.1, tracker.duration * 0.05))"}

--- a/scripts/build_video.sh
+++ b/scripts/build_video.sh
@@ -197,9 +197,11 @@ LOG_DIR="${PROJECT_DIR}/log"
 LOG_FILE="${LOG_DIR}/build.log"
 ERROR_LOG="${LOG_DIR}/error.log"
 CRASH_DIAG_FILE="${LOG_DIR}/crash_diag.log"
+FIRST_PASS_DIAG_FILE="${LOG_DIR}/scene_first_pass_diagnostics.jsonl"
 HEARTBEAT_FILE="${LOG_DIR}/heartbeat.txt"
 HEARTBEAT_INTERVAL_SECONDS="${HEARTBEAT_INTERVAL_SECONDS:-5}"
 HEARTBEAT_PID=""
+REPAIR_ATTEMPT_COUNT=0
 DIAG_PHASE="startup"
 DIAG_STAGE="boot"
 DIAG_SCENE=""
@@ -237,6 +239,50 @@ diagnostics_log() {
       "$ts" "$level" "$$" "$PPID" "${DIAG_PHASE:-}" "${DIAG_STAGE:-}" "${DIAG_SCENE:-}" \
       "${DIAG_ITERATION:-}" "${DIAG_ATTEMPT:-}" "$message"
   } >> "$CRASH_DIAG_FILE"
+}
+
+record_scene_first_pass_diagnostic() {
+  local scene_id="$1"
+  local gate="$2"
+  local failure_summary="$3"
+  local repair_invoked="$4"
+  local attempt_count="${5:-0}"
+
+  SCENE_FIRST_PASS_DIAG_FILE="$FIRST_PASS_DIAG_FILE" \
+  SCENE_ID="$scene_id" \
+  GATE="$gate" \
+  FAILURE_SUMMARY="$failure_summary" \
+  REPAIR_INVOKED="$repair_invoked" \
+  ATTEMPT_COUNT="$attempt_count" \
+  "$PYTHON_BIN" - <<'PY'
+import json
+import os
+from datetime import datetime, UTC
+from pathlib import Path
+
+path = Path(os.environ["SCENE_FIRST_PASS_DIAG_FILE"])
+path.parent.mkdir(parents=True, exist_ok=True)
+
+attempt_raw = os.environ.get("ATTEMPT_COUNT", "0")
+try:
+    attempt_count = int(attempt_raw)
+except ValueError:
+    attempt_count = 0
+
+summary = os.environ.get("FAILURE_SUMMARY", "")
+event = {
+    "timestamp_utc": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    "scene_id": os.environ.get("SCENE_ID", ""),
+    "gate": os.environ.get("GATE", ""),
+    "failure_summary": summary[:2000],
+    "repair_invoked": os.environ.get("REPAIR_INVOKED", "").lower() == "true",
+    "attempt_count": attempt_count,
+}
+
+with path.open("a", encoding="utf-8") as handle:
+    json.dump(event, handle, ensure_ascii=False)
+    handle.write("\n")
+PY
 }
 
 write_heartbeat() {
@@ -1477,8 +1523,10 @@ repair_scene_until_valid() {
   local reason="$4"
 
   local attempt=0
+  REPAIR_ATTEMPT_COUNT=0
   while [[ $attempt -lt $PHASE_RETRY_LIMIT ]]; do
     attempt=$((attempt + 1))
+    REPAIR_ATTEMPT_COUNT=$attempt
     echo "🛠 Self-heal scene ${scene_id} attempt ${attempt}/${PHASE_RETRY_LIMIT}" | tee -a "$LOG_FILE"
 
     if ! reset_scene_from_scaffold "$scene_id" "$scene_file" "$scene_class"; then
@@ -1535,6 +1583,33 @@ repair_scene_until_valid() {
   done
 
   echo "✗ Self-heal exhausted for ${scene_file}" | tee -a "$LOG_FILE"
+  return 1
+}
+
+repair_build_scene_first_pass_failure() {
+  local scene_id="$1"
+  local scene_file="$2"
+  local scene_class="$3"
+  local gate="$4"
+  local reason="$5"
+
+  record_scene_first_pass_diagnostic "$scene_id" "$gate" "$reason" "true" "0"
+  if repair_scene_until_valid "$scene_id" "$scene_file" "$scene_class" "$reason"; then
+    record_scene_first_pass_diagnostic \
+      "$scene_id" \
+      "${gate}:resolved" \
+      "$reason" \
+      "true" \
+      "${REPAIR_ATTEMPT_COUNT:-0}"
+    return 0
+  fi
+
+  record_scene_first_pass_diagnostic \
+    "$scene_id" \
+    "${gate}:unresolved" \
+    "$reason" \
+    "true" \
+    "${REPAIR_ATTEMPT_COUNT:-0}"
   return 1
 }
 
@@ -1951,7 +2026,7 @@ PY
     echo "✗ Template structure validation failed for $new_scene. Attempting self-heal..." | tee -a "$LOG_FILE"
     local template_reason
     template_reason=$(extract_recent_error_excerpt "$new_scene")
-    if ! repair_scene_until_valid "$scene_id" "$new_scene" "$scene_class" "$template_reason"; then
+    if ! repair_build_scene_first_pass_failure "$scene_id" "$new_scene" "$scene_class" "template_structure" "$template_reason"; then
       echo "✗ Self-heal failed after template validation error in $new_scene" | tee -a "$LOG_FILE" >&2
       return 1
     fi
@@ -1964,7 +2039,7 @@ PY
     echo "✗ Syntax check failed for $new_scene. Attempting self-heal..." | tee -a "$LOG_FILE"
     local syntax_reason
     syntax_reason=$(scene_python_syntax_error_excerpt "$new_scene")
-    if ! repair_scene_until_valid "$scene_id" "$new_scene" "$scene_class" "$syntax_reason"; then
+    if ! repair_build_scene_first_pass_failure "$scene_id" "$new_scene" "$scene_class" "python_syntax" "$syntax_reason"; then
       echo "✗ Self-heal failed after syntax error in $new_scene" | tee -a "$LOG_FILE" >&2
       return 1
     fi
@@ -1975,7 +2050,7 @@ PY
     echo "✗ Import validation failed for $new_scene. Attempting self-heal..." | tee -a "$LOG_FILE"
     local import_reason
     import_reason=$(extract_recent_error_excerpt "$new_scene")
-    if ! repair_scene_until_valid "$scene_id" "$new_scene" "$scene_class" "$import_reason"; then
+    if ! repair_build_scene_first_pass_failure "$scene_id" "$new_scene" "$scene_class" "import_api" "$import_reason"; then
       echo "✗ Self-heal failed after import/API error in $new_scene" | tee -a "$LOG_FILE" >&2
       return 1
     fi
@@ -1986,7 +2061,7 @@ PY
     echo "✗ Voiceover sync validation failed for $new_scene. Attempting self-heal..." | tee -a "$LOG_FILE"
     local sync_reason
     sync_reason=$(extract_recent_error_excerpt "$new_scene")
-    if ! repair_scene_until_valid "$scene_id" "$new_scene" "$scene_class" "$sync_reason"; then
+    if ! repair_build_scene_first_pass_failure "$scene_id" "$new_scene" "$scene_class" "voiceover_sync" "$sync_reason"; then
       echo "✗ Self-heal failed after sync error in $new_scene" | tee -a "$LOG_FILE" >&2
       return 1
     fi
@@ -1997,7 +2072,7 @@ PY
     echo "✗ Semantic quality validation failed for $new_scene. Attempting self-heal..." | tee -a "$LOG_FILE"
     local semantic_reason
     semantic_reason=$(extract_recent_error_excerpt "$new_scene")
-    if ! repair_scene_until_valid "$scene_id" "$new_scene" "$scene_class" "$semantic_reason"; then
+    if ! repair_build_scene_first_pass_failure "$scene_id" "$new_scene" "$scene_class" "semantic_quality" "$semantic_reason"; then
       echo "✗ Self-heal failed after semantic validation error in $new_scene" | tee -a "$LOG_FILE" >&2
       return 1
     fi
@@ -2009,7 +2084,7 @@ PY
     echo "✗ Runtime validation failed for $new_scene. Attempting self-heal..." | tee -a "$LOG_FILE"
     local runtime_reason
     runtime_reason=$(extract_recent_error_excerpt "$new_scene")
-    if ! repair_scene_until_valid "$scene_id" "$new_scene" "$scene_class" "$runtime_reason"; then
+    if ! repair_build_scene_first_pass_failure "$scene_id" "$new_scene" "$scene_class" "runtime_dry_run" "$runtime_reason"; then
       echo "✗ Self-heal failed after runtime error in $new_scene" | tee -a "$LOG_FILE" >&2
       return 1
     fi

--- a/scripts/build_video.sh
+++ b/scripts/build_video.sh
@@ -257,7 +257,7 @@ record_scene_first_pass_diagnostic() {
   "$PYTHON_BIN" - <<'PY'
 import json
 import os
-from datetime import datetime, UTC
+from datetime import datetime, timezone
 from pathlib import Path
 
 path = Path(os.environ["SCENE_FIRST_PASS_DIAG_FILE"])
@@ -271,7 +271,7 @@ except ValueError:
 
 summary = os.environ.get("FAILURE_SUMMARY", "")
 event = {
-    "timestamp_utc": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    "timestamp_utc": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
     "scene_id": os.environ.get("SCENE_ID", ""),
     "gate": os.environ.get("GATE", ""),
     "failure_summary": summary[:2000],

--- a/scripts/test_contracts_vs_runtime.py
+++ b/scripts/test_contracts_vs_runtime.py
@@ -229,6 +229,7 @@ def check_first_pass_scene_creation_contract() -> None:
         "attribute_root_name",
         "target_touches_config",
         "is_self_voiceover_call",
+        "is_tracker_duration",
         "tracker.duration",
         "ShowCreation",
         '"lag_ratio"',

--- a/scripts/test_contracts_vs_runtime.py
+++ b/scripts/test_contracts_vs_runtime.py
@@ -199,6 +199,72 @@ def check_scaffold_contract() -> None:
     )
 
 
+def check_first_pass_scene_creation_contract() -> None:
+    build_video = read_text("scripts/build_video.sh")
+    parser = read_text("harness_responses/parser.py")
+    build_system = read_text("harness_responses/prompts/build_scenes/system.md")
+    build_user = read_text("harness_responses/prompts/build_scenes/user.md")
+    prompt_text = f"{build_system}\n{build_user}"
+
+    for required in (
+        "first-pass-valid",
+        "scaffold structure",
+        "Python syntax",
+        "import/API validation",
+        "voiceover sync",
+        "timing budget validation",
+        "semantic placeholder checks",
+        "manim render --dry_run",
+        "ShowCreation",
+        "FadeIn(..., lag_ratio=...)",
+        "FadeIn(..., scale_factor=...)",
+        "set_color(list(...))",
+        "set_color(harmonious_color(...))",
+    ):
+        require(required in prompt_text, f"build_scenes prompt missing {required}")
+
+    for required in (
+        "_validate_scene_body_contract",
+        "tracker.duration",
+        "ShowCreation",
+        "FadeIn\\([^\\n)]*lag_ratio",
+        "set_color\\(\\s*list\\(",
+        "set_color\\(\\s*harmonious_color\\(",
+    ):
+        require(required in parser, f"parser missing first-pass scene validation: {required}")
+
+    require(
+        "FIRST_PASS_DIAG_FILE=\"${LOG_DIR}/scene_first_pass_diagnostics.jsonl\""
+        in build_video,
+        "build_video.sh does not define first-pass diagnostics JSONL path",
+    )
+    require(
+        "record_scene_first_pass_diagnostic()" in build_video,
+        "build_video.sh does not define first-pass diagnostic writer",
+    )
+    require(
+        "json.dump(event" in build_video and '"attempt_count": attempt_count' in build_video,
+        "first-pass diagnostic writer does not emit JSON with attempt_count",
+    )
+    require(
+        "repair_build_scene_first_pass_failure()" in build_video,
+        "build_video.sh does not route build_scenes failures through diagnostic wrapper",
+    )
+    for gate in (
+        "template_structure",
+        "python_syntax",
+        "import_api",
+        "voiceover_sync",
+        "semantic_quality",
+        "runtime_dry_run",
+    ):
+        require(gate in build_video, f"build_scenes first-pass gate not classified: {gate}")
+    require(
+        build_video.count("repair_scene_until_valid") >= 4,
+        "scene repair calls appear to have been removed or weakened",
+    )
+
+
 def check_voice_contract() -> None:
     service_factory = read_text("flaming_horse_voice/service_factory.py")
     require(
@@ -297,6 +363,7 @@ def main() -> int:
     check_harness_docs_contract()
     check_phase_contract()
     check_scaffold_contract()
+    check_first_pass_scene_creation_contract()
     check_voice_contract()
     check_voice_backend_resolution_contract()
     check_removed_live_surfaces()

--- a/scripts/test_contracts_vs_runtime.py
+++ b/scripts/test_contracts_vs_runtime.py
@@ -225,11 +225,16 @@ def check_first_pass_scene_creation_contract() -> None:
 
     for required in (
         "_validate_scene_body_contract",
+        "tokenize.COMMENT",
+        "attribute_root_name",
+        "target_touches_config",
+        "is_self_voiceover_call",
         "tracker.duration",
         "ShowCreation",
-        "FadeIn\\([^\\n)]*lag_ratio",
-        "set_color\\(\\s*list\\(",
-        "set_color\\(\\s*harmonious_color\\(",
+        '"lag_ratio"',
+        '"scale_factor"',
+        '"list"',
+        '"harmonious_color"',
     ):
         require(required in parser, f"parser missing first-pass scene validation: {required}")
 

--- a/tests/harness_responses/test_plan_phase.py
+++ b/tests/harness_responses/test_plan_phase.py
@@ -555,6 +555,89 @@ class TestArtifactWriters:
         content = (project / "scene_01.py").read_text(encoding="utf-8")
         assert "Fixed" in content
 
+    def test_scene_body_empty_or_comment_only_fails(self, tmp_path):
+        project = _make_scene_project(tmp_path)
+        for body in ("", "   ", "# placeholder only"):
+            parsed = BuildScenesResponse(scene_body=body)
+            with pytest.raises(SemanticValidationError):
+                hr_parser.write_phase_artifacts("build_scenes", parsed, project)
+
+    @pytest.mark.parametrize(
+        ("body", "message"),
+        [
+            ("import os\nself.wait(tracker.duration * 0.1)", "must not include imports"),
+            (
+                "class Bad:\n    pass\nself.wait(tracker.duration * 0.1)",
+                "must not include imports, class definitions, or function definitions",
+            ),
+            (
+                "def helper():\n    pass\nself.wait(tracker.duration * 0.1)",
+                "must not include imports, class definitions, or function definitions",
+            ),
+            ("config.frame_width = 1\nself.wait(tracker.duration * 0.1)", "config"),
+            (
+                "with self.voiceover(text=SCRIPT['scene_01']) as tracker:\n    pass",
+                "voiceover wrapper",
+            ),
+            (
+                "# SLOT_START:scene_body\nself.wait(tracker.duration * 0.1)",
+                "comments",
+            ),
+        ],
+    )
+    def test_scene_body_structural_violations_fail(self, tmp_path, body, message):
+        project = _make_scene_project(tmp_path)
+        parsed = BuildScenesResponse(scene_body=body)
+        with pytest.raises(SemanticValidationError, match=message):
+            hr_parser.write_phase_artifacts("build_scenes", parsed, project)
+
+    @pytest.mark.parametrize(
+        ("body", "message"),
+        [
+            (
+                "title = Text('x')\nself.play(Write(title), run_time=1)",
+                "tracker.duration",
+            ),
+            (
+                "self.play(ShowCreation(Line()), run_time=tracker.duration * 0.2)",
+                "ShowCreation",
+            ),
+            (
+                "self.play(FadeIn(Text('x'), lag_ratio=0.2), run_time=tracker.duration * 0.2)",
+                "LaggedStart",
+            ),
+            (
+                "self.play(FadeIn(Text('x'), scale_factor=2), run_time=tracker.duration * 0.2)",
+                "scale_factor",
+            ),
+            (
+                "title = Text('1 &lt; 2')\nself.wait(tracker.duration * 0.1)",
+                "escaped HTML",
+            ),
+            (
+                "title = Text('x')\ntitle.set_color(list(BLUE))\nself.wait(tracker.duration * 0.1)",
+                "set_color",
+            ),
+            (
+                "title = Text('x')\ntitle.set_color(harmonious_color(BLUE))\nself.wait(tracker.duration * 0.1)",
+                "concrete Manim-compatible color",
+            ),
+        ],
+    )
+    def test_scene_body_known_invalid_manim_patterns_fail(self, tmp_path, body, message):
+        project = _make_scene_project(tmp_path)
+        parsed = BuildScenesResponse(scene_body=body)
+        with pytest.raises(SemanticValidationError, match=message):
+            hr_parser.write_phase_artifacts("build_scenes", parsed, project)
+
+    def test_scene_repair_uses_shared_scene_body_validation(self, tmp_path):
+        project = _make_scene_project(tmp_path)
+        parsed = SceneRepairResponse(
+            scene_body="self.play(ShowCreation(Line()), run_time=tracker.duration * 0.2)"
+        )
+        with pytest.raises(SemanticValidationError, match="ShowCreation"):
+            hr_parser.write_phase_artifacts("scene_repair", parsed, project)
+
     def test_write_phase_artifacts_narration(self, tmp_path):
         project = _make_narration_project(tmp_path)
         parsed = NarrationResponse(script={"scene_01": "Hello narration"})
@@ -620,6 +703,38 @@ class TestPromptComposition:
         assert "Build Scenes Phase" in system
         assert "Scene ID: scene_01" in user
         assert "/repo/harness_responses/templates/phase_scenes.md" in user
+
+    def test_build_scenes_prompt_names_first_pass_contract(self, tmp_path):
+        project = _make_scene_project(tmp_path)
+        system, user = hr_prompts.compose_prompt(
+            phase="build_scenes",
+            project_dir=project,
+        )
+        combined = f"{system}\n{user}"
+        assert "first-pass-valid" in combined
+        assert "scaffold structure" in combined
+        assert "Python syntax" in combined
+        assert "import/API validation" in combined
+        assert "voiceover sync" in combined
+        assert "timing budget validation" in combined
+        assert "semantic placeholder checks" in combined
+        assert "manim render --dry_run" in combined
+
+    def test_build_scenes_prompt_forbids_known_failure_patterns(self, tmp_path):
+        project = _make_scene_project(tmp_path)
+        _, user = hr_prompts.compose_prompt(
+            phase="build_scenes",
+            project_dir=project,
+        )
+        assert "JSON only" in user
+        assert "Do not include imports" in user
+        assert "ShowCreation" in user
+        assert "FadeIn(..., lag_ratio=...)" in user
+        assert "FadeIn(..., scale_factor=...)" in user
+        assert "&lt;" in user
+        assert "set_color(list(...))" in user
+        assert "set_color(harmonious_color(...))" in user
+        assert "with self.voiceover" in user
 
     def test_narration_prompt_loads(self, tmp_path):
         project = _make_narration_project(tmp_path)

--- a/tests/harness_responses/test_plan_phase.py
+++ b/tests/harness_responses/test_plan_phase.py
@@ -603,6 +603,10 @@ class TestArtifactWriters:
                 "tracker.duration",
             ),
             (
+                "title = Text('tracker.duration')\nself.wait(1)",
+                "tracker.duration",
+            ),
+            (
                 "self.play(ShowCreation(Line()), run_time=tracker.duration * 0.2)",
                 "ShowCreation",
             ),

--- a/tests/harness_responses/test_plan_phase.py
+++ b/tests/harness_responses/test_plan_phase.py
@@ -583,6 +583,10 @@ class TestArtifactWriters:
                 "# SLOT_START:scene_body\nself.wait(tracker.duration * 0.1)",
                 "comments",
             ),
+            (
+                "title = Text('x')  # trailing note\nself.wait(tracker.duration * 0.1)",
+                "comments",
+            ),
         ],
     )
     def test_scene_body_structural_violations_fail(self, tmp_path, body, message):
@@ -611,10 +615,6 @@ class TestArtifactWriters:
                 "scale_factor",
             ),
             (
-                "title = Text('1 &lt; 2')\nself.wait(tracker.duration * 0.1)",
-                "escaped HTML",
-            ),
-            (
                 "title = Text('x')\ntitle.set_color(list(BLUE))\nself.wait(tracker.duration * 0.1)",
                 "set_color",
             ),
@@ -629,6 +629,20 @@ class TestArtifactWriters:
         parsed = BuildScenesResponse(scene_body=body)
         with pytest.raises(SemanticValidationError, match=message):
             hr_parser.write_phase_artifacts("build_scenes", parsed, project)
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            "title = Text('Avoid ShowCreation(...)')\nself.wait(tracker.duration * 0.1)",
+            "title = Text('randomly chosen examples')\nself.wait(tracker.duration * 0.1)",
+            "expr = MathTex('a &lt; b')\nself.wait(tracker.duration * 0.1)",
+            "title = Text('literal # sign')\nself.wait(tracker.duration * 0.1)",
+        ],
+    )
+    def test_scene_body_validation_ignores_string_literal_text(self, tmp_path, body):
+        project = _make_scene_project(tmp_path)
+        parsed = BuildScenesResponse(scene_body=body)
+        assert hr_parser.write_phase_artifacts("build_scenes", parsed, project) is True
 
     def test_scene_repair_uses_shared_scene_body_validation(self, tmp_path):
         project = _make_scene_project(tmp_path)


### PR DESCRIPTION
## Summary

Strengthens the `build_scenes` contract so first-pass scene generation is responsible for producing valid Manim scaffold-slot bodies, while keeping `scene_repair` as fallback containment.

## Changes

- Tightens build-scenes prompt and schema language around first-pass validity, deterministic gates, conservative Manim APIs, forbidden failure patterns, and narration-synced timing.
- Adds shared parser-level scene-body validation for both `build_scenes` and `scene_repair` before writing generated scene artifacts.
- Records compact first-pass diagnostics when `build_scenes` enters repair, including scene id, gate, failure summary, repair invocation, and attempt count.
- Adds regression coverage for parser validation, prompt contract, and runtime contract drift.

## Validation

- `python3 -m pytest tests/harness_responses/test_plan_phase.py`
- `python3 scripts/test_contracts_vs_runtime.py`
- `python3 scripts/test_update_project_state.py`
- `python3 scripts/test_tts_backend_config.py`
- `python3 scripts/test_qwen_cached_service.py`
- `python3 -m py_compile harness_responses/parser.py harness_responses/prompts.py harness_responses/client.py scripts/test_contracts_vs_runtime.py`
- `bash -n scripts/create_video.sh scripts/new_project.sh scripts/build_video.sh`
- `git diff --check`

## Smoke Test

Ran the normal entrypoint against the Prime Gap Structure proof source:

```bash
./scripts/create_video.sh pgs_proof_first_pass_smoke --topic "Prime Gap Structure proof explained visually. Use /Users/velocityworks/IdeaProjects/prime-gap-structure/PROOF.md as the source document."
```

Result: final video completed successfully at `generated/pgs_proof_first_pass_smoke/final_video.mp4`.

Evidence:

- Project phase reached `complete`.
- `9/9` scenes rendered.
- Scene QC reported `rewrite_required=false` for all scenes.
- No `scene_first_pass_diagnostics.jsonl` was written, which means no build-scenes repair-entry event occurred in this run.
- Final video QC passed with duration `00:06:45.00` and no significant silent gaps.

## Notes

This patch does not remove or weaken `scene_repair`. It makes repair measurable when `build_scenes` fails a first-pass gate.
