### PR TITLE
[codex] Add inter-scene narration gaps

### DIFF
--- a/scripts/build_video.sh
+++ b/scripts/build_video.sh
@@ -64,6 +64,7 @@ PROJECTS_BASE_DIR="${PROJECTS_BASE_DIR:-projects}"
 PROJECT_DEFAULT_NAME="${PROJECT_DEFAULT_NAME:-default_video}"
 PHASE_RETRY_LIMIT="${PHASE_RETRY_LIMIT:-3}"
 PHASE_RETRY_BACKOFF_SECONDS="${PHASE_RETRY_BACKOFF_SECONDS:-2}"
+INTER_SCENE_NARRATION_GAP_SECONDS=3
 TARGET_PHASE=""
 RERENDER_FINAL=""
 RESUME_BUILD=""
@@ -2839,16 +2840,25 @@ PY
     return 0
   fi
 
-  # Assemble with concat filter + audio timestamp normalization (no -c copy)
+  # Assemble with concat filter + audio timestamp normalization (no -c copy).
+  # Each non-final scene holds its final frame and pads matching silence so
+  # narration has a deterministic pause before the next scene begins.
   local ffmpeg_inputs=()
   local filter_inputs=""
   local n=${#scene_files[@]}
+  local filter_complex=""
   for i in $(seq 0 $((n - 1))); do
     ffmpeg_inputs+=( -i "${PROJECT_DIR}/${scene_files[$i]}" )
-    filter_inputs+="[${i}:v:0][${i}:a:0]"
+    if [[ "$i" -lt $((n - 1)) ]]; then
+      filter_complex+="[${i}:v:0]setpts=PTS-STARTPTS,tpad=stop_mode=clone:stop_duration=${INTER_SCENE_NARRATION_GAP_SECONDS}[v${i}];"
+      filter_complex+="[${i}:a:0]asetpts=PTS-STARTPTS,apad=pad_dur=${INTER_SCENE_NARRATION_GAP_SECONDS}[a${i}];"
+    else
+      filter_complex+="[${i}:v:0]setpts=PTS-STARTPTS[v${i}];"
+      filter_complex+="[${i}:a:0]asetpts=PTS-STARTPTS[a${i}];"
+    fi
+    filter_inputs+="[v${i}][a${i}]"
   done
-  local filter_complex
-  filter_complex="${filter_inputs}concat=n=${n}:v=1:a=1[v][a];[a]aresample=async=1:first_pts=0[aout]"
+  filter_complex+="${filter_inputs}concat=n=${n}:v=1:a=1[v][a];[a]aresample=async=1:first_pts=0[aout]"
 
   echo "$ ffmpeg (concat filter) -> final_video.mp4" | tee -a "$LOG_FILE"
   if ! ffmpeg -y \

--- a/scripts/qc_final_video.sh
+++ b/scripts/qc_final_video.sh
@@ -3,6 +3,8 @@
 
 VIDEO="$1"
 PROJECT_DIR="$2"
+EXPECTED_INTER_SCENE_SILENCE_SECONDS=3
+SILENCE_WARNING_THRESHOLD_SECONDS=3.5
 
 if [[ -z "$VIDEO" ]] || [[ -z "$PROJECT_DIR" ]]; then
     echo "Usage: $0 <video_file> <project_dir>"
@@ -64,9 +66,9 @@ SILENCE_COUNT=0
 while IFS= read -r line; do
     if echo "$line" | grep -q "silence_duration"; then
         duration=$(echo "$line" | grep -oE 'silence_duration: [0-9]+\.[0-9]+' | awk '{print $2}')
-        if (( $(echo "$duration > 3.0" | bc -l 2>/dev/null || echo "0") )); then
+        if (( $(echo "$duration > ${SILENCE_WARNING_THRESHOLD_SECONDS}" | bc -l 2>/dev/null || echo "0") )); then
             echo "⚠️  WARNING: Found ${duration}s of silence in video"
-            echo "   May indicate voiceover sync issues"
+            echo "   Expected inter-scene silence is ${EXPECTED_INTER_SCENE_SILENCE_SECONDS}s; longer gaps may indicate voiceover sync issues"
             SILENCE_COUNT=$((SILENCE_COUNT + 1))
         fi
     fi

--- a/scripts/test_inter_scene_gap_assembly.py
+++ b/scripts/test_inter_scene_gap_assembly.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BUILD_VIDEO = REPO_ROOT / "scripts" / "build_video.sh"
+QC_FINAL_VIDEO = REPO_ROOT / "scripts" / "qc_final_video.sh"
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise SystemExit(f"FAIL: {message}")
+
+
+def function_body(script: str, name: str, next_name: str) -> str:
+    start = script.find(f"{name}() {{")
+    require(start >= 0, f"{name} not found")
+    end = script.find(f"\n{next_name}() {{", start)
+    require(end >= 0, f"{next_name} not found after {name}")
+    return script[start:end]
+
+
+def main() -> None:
+    build_script = BUILD_VIDEO.read_text(encoding="utf-8")
+    assemble = function_body(build_script, "handle_assemble", "handle_complete")
+
+    require(
+        "INTER_SCENE_NARRATION_GAP_SECONDS=3" in build_script,
+        "inter-scene gap constant is missing or not fixed at 3 seconds",
+    )
+    require(
+        'if [[ "$i" -lt $((n - 1)) ]]; then' in assemble,
+        "assemble does not distinguish non-final scenes from the final scene",
+    )
+    require(
+        "tpad=stop_mode=clone:stop_duration=${INTER_SCENE_NARRATION_GAP_SECONDS}" in assemble,
+        "assemble does not hold the final frame for non-final scenes",
+    )
+    require(
+        "apad=pad_dur=${INTER_SCENE_NARRATION_GAP_SECONDS}" in assemble,
+        "assemble does not add matching silent audio padding for non-final scenes",
+    )
+    require(
+        "[${i}:v:0]setpts=PTS-STARTPTS[v${i}];" in assemble
+        and "[${i}:a:0]asetpts=PTS-STARTPTS[a${i}];" in assemble,
+        "assemble should leave the final scene unpadded",
+    )
+    require(
+        "concat=n=${n}:v=1:a=1[v][a];[a]aresample=async=1:first_pts=0[aout]" in assemble,
+        "assemble no longer preserves concat plus final audio timestamp normalization",
+    )
+
+    qc_script = QC_FINAL_VIDEO.read_text(encoding="utf-8")
+    require(
+        "EXPECTED_INTER_SCENE_SILENCE_SECONDS=3" in qc_script,
+        "QC does not document the intentional inter-scene silence duration",
+    )
+    require(
+        "SILENCE_WARNING_THRESHOLD_SECONDS=3.5" in qc_script,
+        "QC silence warning threshold should tolerate the expected 3-second gap",
+    )
+    require(
+        "duration > ${SILENCE_WARNING_THRESHOLD_SECONDS}" in qc_script,
+        "QC silence detector does not use the explicit threshold",
+    )
+
+    print("OK")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds a deterministic three-second pause between assembled scenes without changing scene generation, TTS, scene rendering, or the canonical entrypoint.

The assembly phase now pads every non-final scene with:

- a cloned final video frame via `tpad=stop_mode=clone:stop_duration=3`
- matching silent audio via `apad=pad_dur=3`

The final scene is not padded. Final-video QC now treats the expected three-second inter-scene silence as intentional and warns only above the tolerated threshold.

## Validation

- `python3 scripts/test_inter_scene_gap_assembly.py`
- `python3 scripts/test_generate_scenes_txt.py`
- `python3 scripts/test_contracts_vs_runtime.py`
- `python3 -m py_compile scripts/generate_scenes_txt.py scripts/test_inter_scene_gap_assembly.py`
- `bash -n scripts/create_video.sh scripts/new_project.sh scripts/build_video.sh scripts/qc_final_video.sh`
- `git diff --check`
- Full canonical smoke:
  - `./scripts/create_video.sh narration_gap_smoke --topic "A visual explanation of prime numbers"`

Smoke artifact produced:

- `/Users/velocityworks/IdeaProjects/flaming-horse/generated/narration_gap_smoke/final_video.mp4`

Media verification:

- Six scene videos totaled `156.7s`.
- Final video duration was `171.7s`.
- Five inter-scene gaps added exactly `15.0s` total.
- `ffprobe` reported video `171.700s` and audio `171.690s`.
- `silencedetect` found five pauses around `3.2-3.4s` and no trailing final-scene gap.